### PR TITLE
FEAT: Implement connection test with '/response' endpoint

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:allowBackup="true"
@@ -11,9 +12,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Copayappfrontend"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name="com.copay.app.ui.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Copayappfrontend">

--- a/app/src/main/java/com/copay/app/MainActivity.kt
+++ b/app/src/main/java/com/copay/app/MainActivity.kt
@@ -1,47 +1,44 @@
-package com.copay.app
+package com.copay.app.ui
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.copay.app.ui.theme.CopayappfrontendTheme
+import android.app.Activity
+import android.util.Log
+import com.copay.app.utils.ConnectionManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class MainActivity : ComponentActivity() {
+class MainActivity : Activity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            CopayappfrontendTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+        setContentView(android.R.layout.simple_list_item_1)
+
+        // Method to verify the connection with the backend.
+        testApiConnection();
+    }
+
+    private fun testApiConnection() {
+        // Using CoroutineScope to handle the asynchronous call on the IO thread.
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val response = ConnectionManager.testConnection()
+
+                // Returning to the main thread to log the result.
+                withContext(Dispatchers.Main) {
+
+                    if (response != null) {
+                        Log.d("TestConnection", "Connection Successful")
+                    } else {
+                        Log.e("TestConnection", "Error: Response body is null")
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    Log.e("TestConnection", "Exception occurred: ${e.message}", e)
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    CopayappfrontendTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/copay/app/config/ApiService.kt
+++ b/app/src/main/java/com/copay/app/config/ApiService.kt
@@ -1,0 +1,16 @@
+package com.copay.app.config
+
+import retrofit2.http.GET
+import okhttp3.ResponseBody
+import retrofit2.Response
+
+interface ApiService {
+
+    companion object {
+        private const val BASE_PATH = "api/"
+    }
+
+    // Method to test the connection with the client.
+    @GET("${BASE_PATH}response")
+    suspend fun getConnectionResponse(): Response<ResponseBody>
+}

--- a/app/src/main/java/com/copay/app/utils/ConnectionManager.kt
+++ b/app/src/main/java/com/copay/app/utils/ConnectionManager.kt
@@ -1,0 +1,35 @@
+package com.copay.app.utils
+
+import android.util.Log
+import com.copay.app.config.RetrofitInstance
+import okhttp3.ResponseBody
+import retrofit2.Response
+
+object ConnectionManager {
+
+    suspend fun testConnection(): String? {
+        return try {
+            // Hacer la llamada a la API
+            val response: Response<ResponseBody> = RetrofitInstance.api.getConnectionResponse()
+
+            // Verificar si la respuesta fue exitosa
+            if (response.isSuccessful) {
+                val responseBody = response.body()
+                if (responseBody != null) {
+                    // Obtener el cuerpo de la respuesta como texto
+                    return responseBody.string() // Retorna el texto plano
+                } else {
+                    Log.e("TestConnection", "Response body is null")
+                    return null
+                }
+            } else {
+                Log.e("TestConnection", "Error: ${response.code()}")
+                return null
+            }
+        } catch (e: Exception) {
+            // Manejo de excepciones
+            Log.e("TestConnection", "Exception occurred: ${e.message}", e)
+            return null
+        }
+    }
+}


### PR DESCRIPTION
Created ConnectionManager object to handle API connection testing:

  - Added suspend function to make the API call and return the response as plain text.

  - Managed errors and null responses with appropriate logging.

Integrated the connection test in MainActivity, making the API call on app startup:

  - Ensured that the '/response' endpoint is always called when the app is initialized.

Configured ApiService interface:

  - Defined GET request for the '/response' endpoint to test the connection

Added INTERNET permission in AndroidManifest.xml:

  - Included `<uses-permission android:name="android.permission.INTERNET" />` to enable network access.

Closes #9.